### PR TITLE
update decimal range

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
+++ b/src/main/resources/org/jenkinsci/plugins/xunit/types/model/xsd/junit-10.xsd
@@ -22,10 +22,12 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 -->
+
+
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:simpleType name="SUREFIRE_TIME">
         <xs:restriction base="xs:string">
-            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,3})?"/>
+            <xs:pattern value="(([0-9]{0,3},)*[0-9]{3}|[0-9]{0,3})*(\.[0-9]{0,9})?"/><!--Update decimal range in order to fix issue with Junit test reporting -->
         </xs:restriction>
     </xs:simpleType>
 


### PR DESCRIPTION
Minor update to the XSD file in order to fix the time attribute error with Junit result xml which contains more than 3 decimal values. 

```
WARNING: At line 2 of file:/xxx_processed.xml:cvc-attribute.3: The value '159.349000' of attribute 'time' on element 'testsuite' is not valid with respect to its type, 'SUREFIRE_TIME'.
ERROR: Step ‘Publish xUnit test result report’ failed: The result file '/xxx_processed.xml' for the metric 'JUnit' is not valid. The result file has been skipped.
```